### PR TITLE
Fix deadlock in invite-based registration

### DIFF
--- a/handlers/auth.go
+++ b/handlers/auth.go
@@ -148,7 +148,7 @@ func (h *AuthHandler) Register(c *fiber.Ctx) error {
 	var consumedInviteID *uuid.UUID
 	if mustHaveInvite {
 		// First, check if the invite code exists at all
-		_, err := h.inviteRepo.GetByCode(inviteCode)
+		_, err := h.inviteRepo.GetByCodeWithTx(tx, inviteCode)
 		if err == sql.ErrNoRows {
 			return c.Status(fiber.StatusForbidden).JSON(fiber.Map{"error": "Invalid invite code"})
 		}

--- a/models/interfaces.go
+++ b/models/interfaces.go
@@ -60,6 +60,7 @@ type InviteRepositoryInterface interface {
 	Create(maxUses *int, expiresAt *time.Time, createdBy *uuid.UUID) (*Invite, error)
 	List(page, limit int) ([]Invite, int, error)
 	GetByCode(code string) (*Invite, error)
+	GetByCodeWithTx(tx *sqlx.Tx, code string) (*Invite, error)
 	Consume(code string) (*Invite, error)
 	ConsumeWithTx(tx *sqlx.Tx, code string) (*Invite, error)
 	RevertConsume(id uuid.UUID) error

--- a/models/tokens.go
+++ b/models/tokens.go
@@ -119,6 +119,15 @@ func (r *InviteRepository) GetByCode(code string) (*Invite, error) {
 	return &inv, nil
 }
 
+func (r *InviteRepository) GetByCodeWithTx(tx *sqlx.Tx, code string) (*Invite, error) {
+	var inv Invite
+	err := tx.Get(&inv, `SELECT * FROM invites WHERE code=$1`, code)
+	if err != nil {
+		return nil, err
+	}
+	return &inv, nil
+}
+
 // Consume validates and consumes one use of the invite atomically.
 // Returns updated invite or error if invalid/expired/exhausted.
 func (r *InviteRepository) Consume(code string) (*Invite, error) {

--- a/tests/handlers/auth_test.go
+++ b/tests/handlers/auth_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/yourusername/trough/handlers"
@@ -25,6 +26,20 @@ func (m *MockUserRepository) Create(user *models.User) error {
 	args := m.Called(user)
 	user.ID = uuid.New()
 	return args.Error(0)
+}
+
+func (m *MockUserRepository) CreateWithTx(tx *sqlx.Tx, user *models.User) error {
+	args := m.Called(tx, user)
+	user.ID = uuid.New()
+	return args.Error(0)
+}
+
+func (m *MockUserRepository) BeginTx() (*sqlx.Tx, error) {
+	args := m.Called()
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*sqlx.Tx), args.Error(1)
 }
 
 func (m *MockUserRepository) GetByEmail(email string) (*models.User, error) {


### PR DESCRIPTION
When multiple users tried to register using the same invite link, all but the first registration would hang indefinitely.

This was caused by a deadlock in the database connection handling. The registration handler would start a database transaction, and then, within the same handler, make another database query outside of that transaction. With a small database connection pool size (e.g., 1), this would cause the handler to wait for a connection that would never be released, resulting in a hang.

The fix is to perform all database operations within the same transaction. A new method, `GetByCodeWithTx`, was added to the invite repository to allow fetching an invite code within an existing transaction. The registration handler was updated to use this new method.