### PR TITLE
fix: Simplify DB reconnect logic to prevent deadlock

### DIFF
--- a/db/connection.go
+++ b/db/connection.go
@@ -280,12 +280,8 @@ func Reconnect() error {
 	reconnectLock.Lock()
 	defer reconnectLock.Unlock()
 
-	// After acquiring the lock, check if another goroutine has already reconnected.
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	if err := Ping(ctx); err == nil {
-		return nil // Connection is already good.
-	}
+	// The lock ensures this block is only executed by one goroutine at a time.
+	// We proceed directly to closing the old connection and creating a new one.
 
 	if err := Close(); err != nil {
 		// Log the error but don't fail if closing fails, as we're trying to reconnect anyway


### PR DESCRIPTION
This commit is the third attempt to fix a persistent database connection issue. The previous fix introduced a potential deadlock by adding a "double-check" inside the reconnection mutex. This change removes that complexity, resulting in a simpler and safer reconnection mechanism.
The logic is now:
-   The middleware detects a failed/timed-out ping.
-   It calls `Reconnect`.
-   `Reconnect` acquires a lock, unconditionally closes the old connection pool, and creates a new one.